### PR TITLE
DRY local configuration changes and apikey autoloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,29 +38,23 @@ nasdaqdatalink.ApiConfig.verify_ssl = False
 
 ### Local API Key file
 
-The default configuration file location is `~/.nasdaq/data_link_apikey`.
+The default configuration file location is `~/.nasdaq/data_link_apikey`.  The
+client will attempt to load this file if it exists.  Note: if the file exists
+and empty, a ValueError will be thrown.
 
-Save api key locally:
+Save your api key locally:
 ```
 import nasdaqdatalink
 nasdaqdatalink.save_key("supersecret")
 print(nasdaqdatalink.ApiConfig.api_key)
 ```
 
-Load the API Key without exposing the key in the script or notebook
-
-```
-import nasdaqdatalink
-nasdaqdatalink.read_key()
-print(nasdaqdatalink.ApiConfig.api_key)
-```
-
-Set a custom location for the API key file, e.g. store the externally outside a docker container
+Set a custom location for the API key file:
 ```
 import nasdaqdatalink
 nasdaqdatalink.save_key("ourcorporateapikey", filename="/srv/data/somecontainer/.corporatenasdaqdatalinkapikey")
 ```
-and call within the docker container with mount point at `/data`
+Requires an explicit read_key() call with the absolute path:
 ```
 import nasdaqdatalink
 nasdaqdatalink.read_key(filepath="/data/.corporatenasdaqdatalinkapikey")

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ nasdaqdatalink.ApiConfig.verify_ssl = False
 ```
 
 ### Local API Key file
-Save local key to `$HOME/.nasdaq_data_link_api_key` file
+
+The default configuration file location is `~/.nasdaq/data_link_apikey`.
+
+Save api key locally:
 ```
 import nasdaqdatalink
 nasdaqdatalink.save_key("supersecret")
@@ -45,6 +48,7 @@ print(nasdaqdatalink.ApiConfig.api_key)
 ```
 
 Load the API Key without exposing the key in the script or notebook
+
 ```
 import nasdaqdatalink
 nasdaqdatalink.read_key()

--- a/nasdaqdatalink/__init__.py
+++ b/nasdaqdatalink/__init__.py
@@ -15,3 +15,7 @@ from .bulkdownload import bulkdownload
 from .export_table import export_table
 from .get_table import get_table
 from .get_point_in_time import get_point_in_time
+
+
+if api_config.default_config_file_exists():
+    read_key()

--- a/nasdaqdatalink/api_config.py
+++ b/nasdaqdatalink/api_config.py
@@ -36,6 +36,11 @@ def default_config_filename():
     return os.path.expanduser(config_file)
 
 
+def default_config_file_exists():
+    config_filename = default_config_filename()
+    return os.path.isfile(config_filename)
+
+
 def save_key(apikey, filename=None):
     if filename is None:
         filename = default_config_filename()

--- a/nasdaqdatalink/api_config.py
+++ b/nasdaqdatalink/api_config.py
@@ -16,9 +16,30 @@ class ApiConfig:
     verify_ssl = True
 
 
+def create_file(config_filename):
+    # Create the file as well as the parent dir if needed.
+    dirname = os.path.split(config_filename)[0]
+    if not os.path.isdir(dirname):
+        os.makedirs(dirname)
+    with os.fdopen(os.open(config_filename,
+                           os.O_WRONLY | os.O_CREAT, 0o600), 'w'):
+        pass
+
+
+def create_file_if_necessary(config_filename):
+    if not os.path.isfile(config_filename):
+        create_file(config_filename)
+
+
+def default_config_filename():
+    config_file = os.path.join('~', '.nasdaq', 'data_link_apikey')
+    return os.path.expanduser(config_file)
+
+
 def save_key(apikey, filename=None):
     if filename is None:
-        filename = os.path.join(os.path.expanduser('~'), '.nasdaq_data_link_api_key')
+        filename = default_config_filename()
+        create_file_if_necessary(filename)
 
     fileptr = open(filename, 'w')
     fileptr.write(apikey)
@@ -26,14 +47,21 @@ def save_key(apikey, filename=None):
     ApiConfig.api_key = apikey
 
 
+def raise_empty_file(config_filename):
+    raise ValueError("File '{:s}' is empty.".format(config_filename))
+
+
 def read_key(filename=None):
     if filename is None:
-        filename = os.path.join(os.path.expanduser('~'), '.nasdaq_data_link_api_key')
+        filename = default_config_filename()
+
+    if not os.path.isfile(filename):
+        raise_empty_file(filename)
 
     with open(filename, 'r') as f:
         apikey = f.read()
 
     if not apikey:
-        raise ValueError("File '{:s}' is empty.".format(filename))
+        raise_empty_file(filename)
 
     ApiConfig.api_key = apikey


### PR DESCRIPTION
This series introduces a change to reduce duplication of configuration file derivation as well as tucking config files into a default standard path.

Building on top of the standard path, introduce apikey autoload. When imported, attempt to find the apikey in our standard path: if a file exists try to read it.  Adds convenience to avoid unnecessary boilerpate; help prevent people from committing their api key.

A future topic will allow API key to be defined via environment variables.