### PR TITLE
BRAND-6/bump-supported-python-versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nasdaq Data Link Python Client
 
-This is the official documentation for Nasdaq Data Link's Python Package. The package can be used to interact with the latest version of the [Nasdaq Data Link's RESTful API](https://docs.data.nasdaq.com/docs). This package is compatible with python v3.5+.
+This is the official documentation for Nasdaq Data Link's Python Package. The package can be used to interact with the latest version of the [Nasdaq Data Link's RESTful API](https://docs.data.nasdaq.com/docs). This package is compatible with python v3.7+.
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 import os
 import sys
 
-if sys.version_info[:2] < (3, 5):
+if sys.version_info[:2] < (3, 7):
     raise ImportError("""
-    This version of Nasdaq Data Link no longer supports python versions less than 3.5.0. If you're
+    This version of Nasdaq Data Link no longer supports python versions less than 3.7.0. If you're
     reading this message your pip and/or setuptools are outdated. Please run the following to
     update them:
 
@@ -72,14 +72,14 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8"
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10"
     ],
     install_requires=INSTALL_REQUIRES,
     tests_require=TEST_REQUIRES,
-    python_requires='>= 3.5',
+    python_requires='>= 3.7',
     test_suite="nose.collector",
     packages=PACKAGES
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 [tox]
-envlist = py3.5,py3.6,py3.7,py3.8
+envlist = py3.7,py3.8,py3.9,py3.10
 
 [testenv]
 commands =


### PR DESCRIPTION
Support v3.7 and above.