### PR TITLE
documentation: avoid apikey bad practices

### DIFF
--- a/FOR_ANALYSTS.md
+++ b/FOR_ANALYSTS.md
@@ -4,12 +4,9 @@ This quick guide offers convenient ways to retrieve individual datasets or datat
 
 ## Retrieving Data
 
-Retrieving data can be achieved easily using these methods `nasdaqdatalink.get` for datasets, `nasdaqdatalink.get_table` for datatables and `nasdaqdatalink.get_point_in_time` for point in time data. In all cases we strongly recommend that you set your api key via:
+Retrieving data can be achieved easily using these methods `nasdaqdatalink.get` for datasets, `nasdaqdatalink.get_table` for datatables and `nasdaqdatalink.get_point_in_time` for point in time data.
 
- ```python
-import nasdaqdatalink
-nasdaqdatalink.ApiConfig.api_key = 'tEsTkEy123456789'
-```
+We strongly recommend that you set your api key using [environment variable](README.md#Local-API-Key-Environment-Variable) or [local file options](README.md#Local-API-Key-file).
 
 ### Datasets
 
@@ -43,7 +40,7 @@ The following additional parameters can be specified for a dataset call:
 
 | Option | Explanation | Example | Description |
 |--------|-------------|---------|-------------|
-| api_key | Your access key | `api_key='tEsTkEy123456789'` | Used to identify who you are and provide more access. Only required if not set via `nasdaqdatalink.ApiConfig.api_key=` |
+| api_key | Your access key | `api_key='tEsTkEy123456789'` | Used to identify who you are and provide more access. |
 | \<filter / transformation parameter\> | A parameter which filters or transforms the resulting data | `start_date='2010-01-01` | For a full list see our [api docs](https://docs.data.nasdaq.com/docs) |
 
 For more information on how to use and manipulate the resulting data see the [pandas documentation](http://pandas.pydata.org/).
@@ -168,7 +165,7 @@ The following additional parameters can be specified for a datatable call:
 
 | Option | Explanation | Example | Description |
 |---|---|---|---|
-| api_key | Your access key | `api_key='tEsTkEy123456789'` | Used to identify who you are and provide more access. Only required if not set via `nasdaqdatalink.ApiConfig.api_key=` |
+| api_key | Your access key | `api_key='tEsTkEy123456789'` | Used to identify who you are and provide more access. |
 | \<filter / transformation parameter\> | A parameter which filters or transforms the resulting data | `start_date='2010-01-01'` | For a full list see our [api docs](https://docs.data.nasdaq.com/docs) |
 | paginate | Wether to autoamtically paginate data | `paginate=True` | Will paginate through the first few pages of data automatically and merge them together in a larger output format. |
 

--- a/FOR_DEVELOPERS.md
+++ b/FOR_DEVELOPERS.md
@@ -6,16 +6,11 @@ In addition to the Quick methods for retrieving data, some additional commands m
 * Customizing how data is returned more granularly
 * Allowing easier iteration of data
 
-In each of the following sections it is assumed your Nasdaq Data LInk API key has been set via:
-
-```python
-import nasdaqdatalink
-nasdaqdatalink.ApiConfig.api_key = 'tEsTkEy123456789'
-```
-
 ## Retrieving Data
 
 In the following sections, `params={}` represents optional query parameters that can be passed into each call. For more detail on available query parameters please see the [API Documentation](https://docs.data.nasdaq.com/docs).
+
+We strongly recommend that you set your api key using [environment variable](README.md#Local-API-Key-Environment-Variable) or [local file options](README.md#Local-API-Key-file).
 
 ### Dataset
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,8 @@ pip3 install nasdaq-data-link
 | retry_backoff_factor | Determines the amount of time in seconds that should be waited before attempting another retry. Note that this factor is exponential so a `retry_backoff_factor` of 0.5 will cause waits of [0.5, 1, 2, 4, etc]. Only used if `use_retries` is True | 0.5
 | retry_status_codes | A list of HTTP status codes which will trigger a retry to occur. Only used if `use_retries` is True| [429, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511]
 
-```python
-import nasdaqdatalink
-nasdaqdatalink.ApiConfig.api_key = 'tEsTkEy123456789'
-```
-By default, SSL verification is enabled. To bypass SSL verification
+By default, SSL verification is enabled. To bypass SSL verification (not recommended), simply:
+
 ```python
 nasdaqdatalink.ApiConfig.verify_ssl = False
 ```
@@ -46,20 +43,12 @@ The default configuration file location is `~/.nasdaq/data_link_apikey`.  The
 client will attempt to load this file if it exists.  Note: if the file exists
 and empty, a ValueError will be thrown.
 
-Save your api key locally:
-```
-import nasdaqdatalink
-nasdaqdatalink.save_key("supersecret")
-print(nasdaqdatalink.ApiConfig.api_key)
-```
+#### Alternative API Key file location
 
-Set a custom location for the API key file:
-```
-import nasdaqdatalink
-nasdaqdatalink.save_key("ourcorporateapikey", filename="/srv/data/somecontainer/.corporatenasdaqdatalinkapikey")
-```
-Requires an explicit read_key() call with the absolute path:
-```
+Since 1.0.0, the `nasdaq-data-link` module will attempt to autoload your API Key. If you prefer to store it in another location, you must
+explicitly call `read_key()` with a custom path.  See below:
+
+```python
 import nasdaqdatalink
 nasdaqdatalink.read_key(filepath="/data/.corporatenasdaqdatalinkapikey")
 ```
@@ -104,7 +93,6 @@ everything.  Useful to see dependency debug info as well.
 data_link_log = logging.getLogger("nasdaqdatalink")
 data_link_log.setLevel(logging.DEBUG)
 ```
-
 
 ### Detailed Usage
 


### PR DESCRIPTION
Encourage users to rely on setting their api key via environment
variables or a local file instead of following the sample code's bad
practice of setting the api key inline.

Signed-off-by: Jamie Couture <jamie.couture@nasdaq.com>