### PR TITLE
CP-9045/remove-deprecations-during-tests

### DIFF
--- a/nasdaqdatalink/utils/request_type_util.py
+++ b/nasdaqdatalink/utils/request_type_util.py
@@ -1,8 +1,4 @@
-try:
-    from urllib import urlencode
-except ImportError:
-    from urllib.parse import urlencode
-
+from urllib.parse import urlencode
 from nasdaqdatalink.api_config import ApiConfig
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if sys.version_info[:2] < (3, 7):
     reading this message your pip and/or setuptools are outdated. Please run the following to
     update them:
 
-    pip install pip setuptools --upgrade
+    pip install setuptools --upgrade
 
     Then try to reinstall nasdaq-data-link:
 

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,7 @@ if sys.version_info[:2] < (3, 7):
     pip install nasdaq-data-link
     """)
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
-
+from setuptools import setup
 with open('LONG_DESCRIPTION.rst') as f:
     LONG_DESCRIPTION = f.read()
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,11 @@ if sys.version_info[:2] < (3, 7):
     pip install nasdaq-data-link
     """)
 
-from setuptools import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 with open('LONG_DESCRIPTION.rst') as f:
     LONG_DESCRIPTION = f.read()
 

--- a/test/test_datatable_data.py
+++ b/test/test_datatable_data.py
@@ -5,6 +5,7 @@ import json
 import pandas
 import numpy
 import six
+from datetime import datetime
 from nasdaqdatalink.model.data import Data
 from nasdaqdatalink.model.datatable import Datatable
 from nasdaqdatalink.utils.request_type_util import RequestType
@@ -143,10 +144,10 @@ class ListDatatableDataTest(unittest.TestCase):
         datatable = Datatable('ZACKS/FC')
         results = Data.page(datatable, params={})
         df = results.to_pandas()
-        self.assertIsInstance(df['per_end_date'][0], pandas.datetime)
-        self.assertIsInstance(df['per_end_date'][1], pandas.datetime)
-        self.assertIsInstance(df['per_end_date'][2], pandas.datetime)
-        self.assertIsInstance(df['per_end_date'][3], pandas.datetime)
+        self.assertIsInstance(df['per_end_date'][0], datetime)
+        self.assertIsInstance(df['per_end_date'][1], datetime)
+        self.assertIsInstance(df['per_end_date'][2], datetime)
+        self.assertIsInstance(df['per_end_date'][3], datetime)
 
     @parameterized.expand(['GET', 'POST'])
     def test_to_numpy_returns_numpy_object(self, request_method):

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -46,7 +46,9 @@ class GetSingleDatasetTest(unittest.TestCase):
             self.assertEqual(actual_request_headers['x-api-token'], 'api_key_configured')
 
     def test_sets_api_key_using_authtoken_arg(self):
-        get('NSE/OIL', authtoken='api_key')
+        with self.assertWarns(DeprecationWarning):
+            get('NSE/OIL', authtoken='api_key')
+
         self.assertEqual(ApiConfig.api_key, 'api_key')
 
     def test_sets_api_key_using_api_key_arg(self):
@@ -55,9 +57,11 @@ class GetSingleDatasetTest(unittest.TestCase):
 
     @patch.object(Dataset, 'data')
     def test_query_params_are_formed_with_old_arg_names(self, mock_method):
-        get('NSE/OIL', authtoken='authtoken', trim_start='2001-01-01',
-            trim_end='2010-01-01', collapse='annual',
-            transformation='rdiff', rows=4, sort_order='desc')
+        with self.assertWarns(DeprecationWarning):
+            get('NSE/OIL', authtoken='authtoken', trim_start='2001-01-01',
+                trim_end='2010-01-01', collapse='annual',
+                transformation='rdiff', rows=4, sort_order='desc')
+
         self.assertEqual(mock_method.call_count, 1)
         self.assertEqual(mock_method.mock_calls[0],
                          call(handle_column_not_found=True,
@@ -129,10 +133,11 @@ class GetMultipleDatasetsTest(unittest.TestCase):
 
     @patch.object(MergedDataset, 'data')
     def test_query_params_are_formed_with_old_arg_names(self, mock_method):
-        get(['WIKI/AAPL.1', 'WIKI/MSFT.2', 'NSE/OIL'],
-            authtoken='authtoken', trim_start='2001-01-01',
-            trim_end='2010-01-01', collapse='annual',
-            transformation='rdiff', rows=4, sort_order='desc')
+        with self.assertWarns(DeprecationWarning):
+            get(['WIKI/AAPL.1', 'WIKI/MSFT.2', 'NSE/OIL'],
+                authtoken='authtoken', trim_start='2001-01-01',
+                trim_end='2010-01-01', collapse='annual',
+                transformation='rdiff', rows=4, sort_order='desc')
 
         self.assertEqual(mock_method.call_count, 1)
         self.assertEqual(mock_method.mock_calls[0],

--- a/test/test_get_point_in_time_data.py
+++ b/test/test_get_point_in_time_data.py
@@ -29,69 +29,93 @@ class GetPointInTimeTest(unittest.TestCase):
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_get_point_in_time_returns_data_frame_object(self, mock):
-        df = nasdaqdatalink.get_point_in_time('ZACKS/FC', interval='asofdate', date='2020-01-01')
+        with self.assertWarns(UserWarning):
+            df = nasdaqdatalink.get_point_in_time(
+                'ZACKS/FC', interval='asofdate', date='2020-01-01'
+            )
+
         self.assertIsInstance(df, pandas.core.frame.DataFrame)
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_asofdate_call_connection(self, mock):
-        nasdaqdatalink.get_point_in_time('ZACKS/FC', interval='asofdate', date='2020-01-01')
-        expected = call('get', 'pit/ZACKS/FC/asofdate/2020-01-01', params={})
+        with self.assertWarns(UserWarning):
+            nasdaqdatalink.get_point_in_time('ZACKS/FC', interval='asofdate', date='2020-01-01')
+            expected = call('get', 'pit/ZACKS/FC/asofdate/2020-01-01', params={})
+
         self.assertEqual(mock.call_args, expected)
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_asofdate_call_connection_with_datetimes(self, mock):
-        nasdaqdatalink.get_point_in_time('ZACKS/FC', interval='asofdate', date='2020-01-01T12:55')
-        expected = call('get', 'pit/ZACKS/FC/asofdate/2020-01-01T12:55', params={})
+        with self.assertWarns(UserWarning):
+            nasdaqdatalink.get_point_in_time(
+                'ZACKS/FC', interval='asofdate', date='2020-01-01T12:55'
+            )
+            expected = call('get', 'pit/ZACKS/FC/asofdate/2020-01-01T12:55', params={})
+
         self.assertEqual(mock.call_args, expected)
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_asofdate_call_without_date(self, mock):
-        nasdaqdatalink.get_point_in_time('ZACKS/FC', interval='asofdate')
-        expected = call('get', "pit/ZACKS/FC/asofdate/%s" % date.today(), params={})
+        with self.assertWarns(UserWarning):
+            nasdaqdatalink.get_point_in_time('ZACKS/FC', interval='asofdate')
+            expected = call('get', "pit/ZACKS/FC/asofdate/%s" % date.today(), params={})
+
         self.assertEqual(mock.call_args, expected)
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_from_call_connection(self, mock):
-        nasdaqdatalink.get_point_in_time(
-            'ZACKS/FC',
-            interval='from',
-            start_date='2020-01-01',
-            end_date='2020-01-02'
-        )
-        expected = call('get', 'pit/ZACKS/FC/from/2020-01-01/to/2020-01-02', params={})
+        with self.assertWarns(UserWarning):
+            nasdaqdatalink.get_point_in_time(
+                'ZACKS/FC',
+                interval='from',
+                start_date='2020-01-01',
+                end_date='2020-01-02'
+            )
+            expected = call('get', 'pit/ZACKS/FC/from/2020-01-01/to/2020-01-02', params={})
+
         self.assertEqual(mock.call_args, expected)
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_from_call_connection_with_datetimes(self, mock):
-        nasdaqdatalink.get_point_in_time(
-            'ZACKS/FC',
-            interval='from',
-            start_date='2020-01-01T12:00',
-            end_date='2020-01-02T14:00'
-        )
-        expected = call('get', 'pit/ZACKS/FC/from/2020-01-01T12:00/to/2020-01-02T14:00', params={})
+        with self.assertWarns(UserWarning):
+            nasdaqdatalink.get_point_in_time(
+                'ZACKS/FC',
+                interval='from',
+                start_date='2020-01-01T12:00',
+                end_date='2020-01-02T14:00'
+            )
+            expected = call(
+                'get', 'pit/ZACKS/FC/from/2020-01-01T12:00/to/2020-01-02T14:00', params={}
+            )
+
         self.assertEqual(mock.call_args, expected)
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_between_call_connection(self, mock):
-        nasdaqdatalink.get_point_in_time(
-            'ZACKS/FC',
-            interval='between',
-            start_date='2020-01-01',
-            end_date='2020-01-02'
-        )
-        expected = call('get', 'pit/ZACKS/FC/between/2020-01-01/2020-01-02', params={})
+        with self.assertWarns(UserWarning):
+            nasdaqdatalink.get_point_in_time(
+                'ZACKS/FC',
+                interval='between',
+                start_date='2020-01-01',
+                end_date='2020-01-02'
+            )
+            expected = call('get', 'pit/ZACKS/FC/between/2020-01-01/2020-01-02', params={})
+
         self.assertEqual(mock.call_args, expected)
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_between_call_connection_with_datetimes(self, mock):
-        nasdaqdatalink.get_point_in_time(
-            'ZACKS/FC',
-            interval='between',
-            start_date='2020-01-01T12:00',
-            end_date='2020-01-02T14:00'
-        )
-        expected = call('get', 'pit/ZACKS/FC/between/2020-01-01T12:00/2020-01-02T14:00', params={})
+        with self.assertWarns(UserWarning):
+            nasdaqdatalink.get_point_in_time(
+                'ZACKS/FC',
+                interval='between',
+                start_date='2020-01-01T12:00',
+                end_date='2020-01-02T14:00'
+            )
+            expected = call(
+                'get', 'pit/ZACKS/FC/between/2020-01-01T12:00/2020-01-02T14:00', params={}
+            )
+
         self.assertEqual(mock.call_args, expected)
 
     @patch('nasdaqdatalink.connection.Connection.request')

--- a/test/test_get_table.py
+++ b/test/test_get_table.py
@@ -39,65 +39,81 @@ class GetDataTableTest(unittest.TestCase):
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_datatable_returns_datatable_object(self, mock):
-        df = nasdaqdatalink.get_table('ZACKS/FC', params={})
+        with self.assertWarns(UserWarning):
+            df = nasdaqdatalink.get_table('ZACKS/FC', params={})
+
         self.assertIsInstance(df, pandas.core.frame.DataFrame)
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_datatable_with_code_returns_datatable_object(self, mock):
-        df = nasdaqdatalink.get_table('AR/MWCF', code="ICEP_WAC_Z2017_S")
+        with self.assertWarns(UserWarning):
+            df = nasdaqdatalink.get_table('AR/MWCF', code="ICEP_WAC_Z2017_S")
+
         self.assertIsInstance(df, pandas.core.frame.DataFrame)
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_get_table_calls_connection_with_no_params_for_get_request(self, mock):
-        nasdaqdatalink.get_table('ZACKS/FC')
-        expected = call('get', 'datatables/ZACKS/FC', params={})
+        with self.assertWarns(UserWarning):
+            nasdaqdatalink.get_table('ZACKS/FC')
+            expected = call('get', 'datatables/ZACKS/FC', params={})
+
         self.assertEqual(mock.call_args, expected)
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_get_table_calls_connection_with_no_params_for_post_request(self, mock):
-        RequestType.USE_GET_REQUEST = False
+        with self.assertWarns(UserWarning):
+            RequestType.USE_GET_REQUEST = False
 
-        nasdaqdatalink.get_table('ZACKS/FC')
-        expected = call('post', 'datatables/ZACKS/FC', json={})
+            nasdaqdatalink.get_table('ZACKS/FC')
+            expected = call('post', 'datatables/ZACKS/FC', json={})
+
         self.assertEqual(mock.call_args, expected)
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_get_table_calls_connection_with_params_for_get_request(self, mock):
-        params = {'ticker': ['AAPL', 'MSFT'],
-                  'per_end_date': {'gte': '2015-01-01'},
-                  'qopts': {'columns': ['ticker', 'per_end_date']},
-                  'foo': 'bar',
-                  'baz': 4
-                  }
+        with self.assertWarns(UserWarning):
+            params = {
+                'ticker': ['AAPL', 'MSFT'],
+                'per_end_date': {'gte': '2015-01-01'},
+                'qopts': {'columns': ['ticker', 'per_end_date']},
+                'foo': 'bar',
+                'baz': 4
+            }
 
-        expected_params = {'ticker[]': ['AAPL', 'MSFT'],
-                           'per_end_date.gte': '2015-01-01',
-                           'qopts.columns[]': ['ticker', 'per_end_date'],
-                           'foo': 'bar',
-                           'baz': 4
-                           }
+            expected_params = {
+                'ticker[]': ['AAPL', 'MSFT'],
+                'per_end_date.gte': '2015-01-01',
+                'qopts.columns[]': ['ticker', 'per_end_date'],
+                'foo': 'bar',
+                'baz': 4
+            }
 
-        nasdaqdatalink.get_table('ZACKS/FC', **params)
-        expected = call('get', 'datatables/ZACKS/FC', params=expected_params)
+            nasdaqdatalink.get_table('ZACKS/FC', **params)
+            expected = call('get', 'datatables/ZACKS/FC', params=expected_params)
+
         self.assertEqual(mock.call_args, expected)
 
     @patch('nasdaqdatalink.connection.Connection.request')
     def test_get_table_calls_connection_with_params_for_post_request(self, mock):
-        RequestType.USE_GET_REQUEST = False
-        params = {'ticker': ['AAPL', 'MSFT'],
-                  'per_end_date': {'gte': '2015-01-01'},
-                  'qopts': {'columns': ['ticker', 'per_end_date']},
-                  'foo': 'bar',
-                  'baz': 4
-                  }
+        with self.assertWarns(UserWarning):
+            RequestType.USE_GET_REQUEST = False
+            params = {
+                'ticker': ['AAPL', 'MSFT'],
+                'per_end_date': {'gte': '2015-01-01'},
+                'qopts': {'columns': ['ticker', 'per_end_date']},
+                'foo': 'bar',
+                'baz': 4
+            }
 
-        expected_params = {'ticker': ['AAPL', 'MSFT'],
-                           'per_end_date.gte': '2015-01-01',
-                           'qopts.columns': ['ticker', 'per_end_date'],
-                           'foo': 'bar',
-                           'baz': 4
-                           }
+            expected_params = {
+                'ticker': ['AAPL', 'MSFT'],
+                'per_end_date.gte': '2015-01-01',
+                'qopts.columns': ['ticker', 'per_end_date'],
+                'foo': 'bar',
+                'baz': 4
+            }
 
-        nasdaqdatalink.get_table('ZACKS/FC', **params)
-        expected = call('post', 'datatables/ZACKS/FC', json=expected_params)
+            nasdaqdatalink.get_table('ZACKS/FC', **params)
+            expected = call('post', 'datatables/ZACKS/FC', json=expected_params)
+
         self.assertEqual(mock.call_args, expected)

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,8 @@ envlist = py3.7,py3.8,py3.9,py3.10
 
 [testenv]
 commands =
-    nosetests
+    nosetests {posargs}
     flake8
-    python -W always setup.py -q test
 deps =
     nose
     flake8


### PR DESCRIPTION
Removed deprecated code
Stubbed warnings to make test output clean
Removed python -W always setup.py -q test since it was deprecated
Added ability to run tests individually
Removed code to support older versions of Python