### PR TITLE
feat: Trim API-key file

### DIFF
--- a/nasdaqdatalink/api_config.py
+++ b/nasdaqdatalink/api_config.py
@@ -68,12 +68,12 @@ def read_key_from_file(filename=None):
         raise_empty_file(filename)
 
     with open(filename, 'r') as f:
-        apikey = f.read()
+        api_key = f.read().split(" ")[0]
 
-    if not apikey:
+    if not api_key:
         raise_empty_file(filename)
 
-    ApiConfig.api_key = apikey
+    ApiConfig.api_key = api_key
 
 
 def api_key_environment_variable_exists():


### PR DESCRIPTION
This commit fixes a bug which happened on my machine (MacOS Monterey
12.1) - when pasting the key from the webpage into the apikey-file in the
default directory, the python API broke - complaining on both "\n" file
endings and spaces.

Splitting on a space makes sense I believe, since the API-key are
presumably never (reject this PR if so) space-inclusive.