### PR TITLE
api_config: avoid whitespace issues in config

### DIFF
--- a/nasdaqdatalink/api_config.py
+++ b/nasdaqdatalink/api_config.py
@@ -60,6 +60,10 @@ def raise_empty_file(config_filename):
     raise ValueError("File '{:s}' is empty.".format(config_filename))
 
 
+def raise_empty_environment_variable():
+    raise ValueError("NASDAQ_DATA_LINK_API_KEY cannot be empty")
+
+
 def get_first_non_empty(file_handle):
     lines = [line.strip() for line in file_handle.readlines()]
     return next((line for line in lines if line), None)
@@ -86,7 +90,11 @@ def api_key_environment_variable_exists():
 
 
 def read_key_from_environment_variable():
-    ApiConfig.api_key = os.environ.get(NASDAQ_DATA_LINK_API_KEY)
+    apikey = os.environ.get(NASDAQ_DATA_LINK_API_KEY)
+    if not apikey:
+        raise_empty_environment_variable()
+
+    ApiConfig.api_key = apikey
 
 
 def read_key(filename=None):

--- a/nasdaqdatalink/api_config.py
+++ b/nasdaqdatalink/api_config.py
@@ -60,6 +60,11 @@ def raise_empty_file(config_filename):
     raise ValueError("File '{:s}' is empty.".format(config_filename))
 
 
+def get_first_non_empty(file_handle):
+    lines = [line.strip() for line in file_handle.readlines()]
+    return next((line for line in lines if line), None)
+
+
 def read_key_from_file(filename=None):
     if filename is None:
         filename = default_config_filename()
@@ -68,7 +73,7 @@ def read_key_from_file(filename=None):
         raise_empty_file(filename)
 
     with open(filename, 'r') as f:
-        apikey = f.read()
+        apikey = get_first_non_empty(f)
 
     if not apikey:
         raise_empty_file(filename)

--- a/test/test_api_config.py
+++ b/test/test_api_config.py
@@ -4,12 +4,16 @@ import os
 from unittest import TestCase, mock
 from nasdaqdatalink.api_config import *
 
+TEST_BASE_PATH = os.path.join(
+  os.path.dirname(os.path.realpath(__file__)), ".nasdaq-config"
+)
+
 TEST_KEY_FILE = os.path.join(
-  os.path.dirname(os.path.realpath(__file__)), ".nasdaq-config", "testkeyfile"
+  TEST_BASE_PATH, "testkeyfile"
 )
 
 TEST_DEFAULT_FILE = os.path.join(
-  os.path.dirname(os.path.realpath(__file__)), ".nasdaq-config", "defaultkeyfile"
+  TEST_BASE_PATH, "defaultkeyfile"
 )
 
 TEST_DEFAULT_FILE_CONTENTS = 'keyfordefaultfile'
@@ -33,6 +37,8 @@ class ApiConfigTest(TestCase):
 
         if os.path.exists(TEST_DEFAULT_FILE):
             os.remove(TEST_DEFAULT_FILE)
+
+        os.removedirs(TEST_BASE_PATH)
 
 
     def test_read_key_when_environment_variable_set(self):

--- a/test/test_api_config.py
+++ b/test/test_api_config.py
@@ -65,6 +65,12 @@ class ApiConfigTest(TestCase):
                 read_key()
 
 
+    def test_read_key_when_env_key_empty(self):
+        os.environ['NASDAQ_DATA_LINK_API_KEY'] = ''
+        with self.assertRaises(ValueError):
+            read_key()
+
+
     def test_read_key_when_files_not_set(self):
         ApiConfig.api_key = None
         with mock.patch("nasdaqdatalink.api_config.default_config_filename") as mock_default_config_filename:

--- a/test/test_api_config.py
+++ b/test/test_api_config.py
@@ -12,6 +12,8 @@ TEST_DEFAULT_FILE = os.path.join(
   os.path.dirname(os.path.realpath(__file__)), ".nasdaq-config", "defaultkeyfile"
 )
 
+TEST_DEFAULT_FILE_CONTENTS = 'keyfordefaultfile'
+
 
 class ApiConfigTest(TestCase):
     def setUp(self):
@@ -55,6 +57,14 @@ class ApiConfigTest(TestCase):
         self.assertEqual(ApiConfig.api_key, 'keyforfile')
 
 
+    def test_read_key_empty_file(self):
+        with mock.patch("nasdaqdatalink.api_config.default_config_filename") as mock_default_config_filename:
+            mock_default_config_filename.return_value = TEST_DEFAULT_FILE
+            save_key("")
+            with self.assertRaises(ValueError):
+                read_key()
+
+
     def test_read_key_when_files_not_set(self):
         ApiConfig.api_key = None
         with mock.patch("nasdaqdatalink.api_config.default_config_filename") as mock_default_config_filename:
@@ -74,3 +84,38 @@ class ApiConfigTest(TestCase):
              read_key()
 
         self.assertEqual(ApiConfig.api_key, 'keyfordefaultfile')
+
+    def _read_key_from_file_helper(self, given, expected):
+        save_key(given, TEST_DEFAULT_FILE)
+        ApiConfig.api_key = None # Set None, we are not testing save_key
+
+        with mock.patch("nasdaqdatalink.api_config.default_config_filename") as mock_default_config_filename:
+             mock_default_config_filename.return_value = TEST_DEFAULT_FILE
+             read_key()
+
+        self.assertEqual(ApiConfig.api_key, expected)
+
+
+    def test_read_key_from_file_with_newline(self):
+        given = f"{TEST_DEFAULT_FILE_CONTENTS}\n"
+        self._read_key_from_file_helper(given, TEST_DEFAULT_FILE_CONTENTS)
+
+
+    def test_read_key_from_file_with_leading_newline(self):
+        given = f"\n{TEST_DEFAULT_FILE_CONTENTS}\n"
+        self._read_key_from_file_helper(given, TEST_DEFAULT_FILE_CONTENTS)
+
+
+    def test_read_key_from_file_with_space(self):
+        given = f" {TEST_DEFAULT_FILE_CONTENTS} "
+        self._read_key_from_file_helper(given, TEST_DEFAULT_FILE_CONTENTS)
+
+
+    def test_read_key_from_file_with_tab(self):
+        given = f"\t{TEST_DEFAULT_FILE_CONTENTS}\t"
+        self._read_key_from_file_helper(given, TEST_DEFAULT_FILE_CONTENTS)
+
+
+    def test_read_key_from_file_with_multi_newline(self):
+        given = "keyfordefaultfile\n\nanotherkey\n"
+        self._read_key_from_file_helper(given, TEST_DEFAULT_FILE_CONTENTS)

--- a/test/test_api_config.py
+++ b/test/test_api_config.py
@@ -80,8 +80,8 @@ class ApiConfigTest(TestCase):
     def test_read_key_when_files_not_set(self):
         ApiConfig.api_key = None
         with mock.patch("nasdaqdatalink.api_config.default_config_filename") as mock_default_config_filename:
-             mock_default_config_filename.return_value = TEST_DEFAULT_FILE
-             read_key()
+            mock_default_config_filename.return_value = TEST_DEFAULT_FILE
+            read_key()
 
         mock_default_config_filename.assert_called_once
         self.assertEqual(ApiConfig.api_key, None)
@@ -92,18 +92,19 @@ class ApiConfigTest(TestCase):
         ApiConfig.api_key = None # Set None, we are not testing save_key
 
         with mock.patch("nasdaqdatalink.api_config.default_config_filename") as mock_default_config_filename:
-             mock_default_config_filename.return_value = TEST_DEFAULT_FILE
-             read_key()
+            mock_default_config_filename.return_value = TEST_DEFAULT_FILE
+            read_key()
 
         self.assertEqual(ApiConfig.api_key, 'keyfordefaultfile')
+
 
     def _read_key_from_file_helper(self, given, expected):
         save_key(given, TEST_DEFAULT_FILE)
         ApiConfig.api_key = None # Set None, we are not testing save_key
 
         with mock.patch("nasdaqdatalink.api_config.default_config_filename") as mock_default_config_filename:
-             mock_default_config_filename.return_value = TEST_DEFAULT_FILE
-             read_key()
+            mock_default_config_filename.return_value = TEST_DEFAULT_FILE
+            read_key()
 
         self.assertEqual(ApiConfig.api_key, expected)
 


### PR DESCRIPTION
When users create add their API Key to a config file it is possible that
whitespace accidentally added into the file will cause issues when
constructing the URI.  Fix API call failures by trying harder to remove
whitespace in the file.  Ensure read_key() will strip whitespace and
only use the first line.

Signed-off-by: Jamie Couture <jamie.couture@nasdaq.com>