### PR TITLE
strip api key

### DIFF
--- a/nasdaqdatalink/api_config.py
+++ b/nasdaqdatalink/api_config.py
@@ -82,7 +82,7 @@ def read_key_from_file(filename=None):
     if not apikey:
         raise_empty_file(filename)
 
-    ApiConfig.api_key = apikey
+    ApiConfig.api_key = apikey.strip()
 
 
 def api_key_environment_variable_exists():


### PR DESCRIPTION
The api key loaded during initialization causes it to include a new line character. As a result the new line is passed onto the HTTP request which results in an error during any HTTP request.

```python
ValueError: Invalid header value b'[redacted_key]\n'
```

This problem is solved by stripping the key during an initial loading of white space present before or after the API text.