### PR TITLE
session-per-request to session-over-time

### DIFF
--- a/nasdaqdatalink/connection.py
+++ b/nasdaqdatalink/connection.py
@@ -36,7 +36,7 @@ def request(http_verb, url, **options):
     return execute_request(http_verb, abs_url, **options)
 
 def execute_request(http_verb, url, **options):
-    session = get_session(url)
+    session = get_session()
 
     try:
         response = session.request(method=http_verb,
@@ -67,10 +67,10 @@ def get_retries():
     return retries
 
 session = requests.Session()
+adapter = HTTPAdapter(max_retries=get_retries())
+session.mount(ApiConfig.api_protocol, adapter)
 
-def get_session(url = ApiConfig.api_protocol):
-    adapter = HTTPAdapter(max_retries=get_retries())
-    session.mount(url, adapter)
+def get_session():
     return session
 
 def parse(response):

--- a/nasdaqdatalink/connection.py
+++ b/nasdaqdatalink/connection.py
@@ -80,7 +80,6 @@ def get_retries():
 def get_session():
     global session
     if session is None:
-        print("initialized")
         session = requests.Session()
         adapter = HTTPAdapter(max_retries=get_retries())
         session.mount(ApiConfig.api_protocol, adapter)

--- a/nasdaqdatalink/connection.py
+++ b/nasdaqdatalink/connection.py
@@ -66,11 +66,14 @@ def get_retries():
 
     return retries
 
-session = requests.Session()
-adapter = HTTPAdapter(max_retries=get_retries())
-session.mount(ApiConfig.api_protocol, adapter)
+session = None
 
 def get_session():
+    global session
+    if session is None:
+        session = requests.Session()
+        adapter = HTTPAdapter(max_retries=get_retries())
+        session.mount(ApiConfig.api_protocol, adapter)
     return session
 
 def parse(response):

--- a/nasdaqdatalink/model/database.py
+++ b/nasdaqdatalink/model/database.py
@@ -4,7 +4,7 @@ from six.moves.urllib.parse import urlencode, urlparse
 
 import nasdaqdatalink.model.dataset
 from nasdaqdatalink.api_config import ApiConfig
-import nasdaqdatalink.connection as Connection
+import nasdaqdatalink.connection as connection
 from nasdaqdatalink.errors.data_link_error import DataLinkError
 from nasdaqdatalink.message import Message
 from nasdaqdatalink.operations.get import GetOperation
@@ -43,7 +43,7 @@ class Database(GetOperation, ListOperation, ModelBase):
         path_url = self._bulk_download_path()
 
         options['stream'] = True
-        r = Connection.request('get', path_url, **options)
+        r = connection.request('get', path_url, **options)
         file_path = file_or_folder_path
         if os.path.isdir(file_or_folder_path):
             file_path = file_or_folder_path + '/' + os.path.basename(urlparse(r.url).path)

--- a/nasdaqdatalink/model/database.py
+++ b/nasdaqdatalink/model/database.py
@@ -4,7 +4,7 @@ from six.moves.urllib.parse import urlencode, urlparse
 
 import nasdaqdatalink.model.dataset
 from nasdaqdatalink.api_config import ApiConfig
-from nasdaqdatalink.connection import Connection
+import nasdaqdatalink.connection as Connection
 from nasdaqdatalink.errors.data_link_error import DataLinkError
 from nasdaqdatalink.message import Message
 from nasdaqdatalink.operations.get import GetOperation

--- a/nasdaqdatalink/model/datatable.py
+++ b/nasdaqdatalink/model/datatable.py
@@ -3,7 +3,7 @@ from time import sleep
 
 from six.moves.urllib.request import urlopen
 
-import nasdaqdatalink.connection as Connection
+import nasdaqdatalink.connection as connection
 from nasdaqdatalink.errors.data_link_error import DataLinkError
 from nasdaqdatalink.message import Message
 from nasdaqdatalink.operations.get import GetOperation
@@ -51,7 +51,7 @@ class Datatable(GetOperation, ListOperation, ModelBase):
 
         updated_options = Util.convert_options(request_type=request_type, **options)
 
-        r = Connection.request(request_type, url, **updated_options)
+        r = connection.request(request_type, url, **updated_options)
 
         response_data = r.json()
 

--- a/nasdaqdatalink/model/datatable.py
+++ b/nasdaqdatalink/model/datatable.py
@@ -3,7 +3,7 @@ from time import sleep
 
 from six.moves.urllib.request import urlopen
 
-from nasdaqdatalink.connection import Connection
+import nasdaqdatalink.connection as Connection
 from nasdaqdatalink.errors.data_link_error import DataLinkError
 from nasdaqdatalink.message import Message
 from nasdaqdatalink.operations.get import GetOperation

--- a/nasdaqdatalink/operations/get.py
+++ b/nasdaqdatalink/operations/get.py
@@ -1,7 +1,7 @@
 from inflection import singularize
 
 from .operation import Operation
-from nasdaqdatalink.connection import Connection
+import nasdaqdatalink.connection as Connection
 from nasdaqdatalink.util import Util
 
 

--- a/nasdaqdatalink/operations/get.py
+++ b/nasdaqdatalink/operations/get.py
@@ -1,7 +1,7 @@
 from inflection import singularize
 
 from .operation import Operation
-import nasdaqdatalink.connection as Connection
+import nasdaqdatalink.connection as connection
 from nasdaqdatalink.util import Util
 
 
@@ -21,7 +21,7 @@ class GetOperation(Operation):
 
         path = Util.constructed_path(cls.get_path(), options['params'])
 
-        r = Connection.request('get', path, **options)
+        r = connection.request('get', path, **options)
         response_data = r.json()
         Util.convert_to_dates(response_data)
         self._raw_data = response_data[singularize(cls.lookup_key())]

--- a/nasdaqdatalink/operations/list.py
+++ b/nasdaqdatalink/operations/list.py
@@ -1,5 +1,5 @@
 from .operation import Operation
-from nasdaqdatalink.connection import Connection
+import nasdaqdatalink.connection as Connection
 from nasdaqdatalink.util import Util
 from nasdaqdatalink.model.paginated_list import PaginatedList
 from nasdaqdatalink.utils.request_type_util import RequestType

--- a/nasdaqdatalink/operations/list.py
+++ b/nasdaqdatalink/operations/list.py
@@ -1,5 +1,5 @@
 from .operation import Operation
-import nasdaqdatalink.connection as Connection
+import nasdaqdatalink.connection as connection
 from nasdaqdatalink.util import Util
 from nasdaqdatalink.model.paginated_list import PaginatedList
 from nasdaqdatalink.utils.request_type_util import RequestType
@@ -12,7 +12,7 @@ class ListOperation(Operation):
         if 'params' not in options:
             options['params'] = {}
         path = Util.constructed_path(cls.list_path(), options['params'])
-        r = Connection.request('get', path, **options)
+        r = connection.request('get', path, **options)
         response_data = r.json()
         Util.convert_to_dates(response_data)
         resource = cls.create_list_from_response(response_data)
@@ -27,7 +27,7 @@ class ListOperation(Operation):
 
         updated_options = Util.convert_options(request_type=request_type, **options)
 
-        r = Connection.request(request_type, path, **updated_options)
+        r = connection.request(request_type, path, **updated_options)
 
         response_data = r.json()
         Util.convert_to_dates(response_data)

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -81,3 +81,15 @@ class ConnectionTest(ModifyRetrySettingsTestCase):
                                  'request-source-version': VERSION},
                         params={'per_page': 10, 'page': 2})
         self.assertEqual(mock.call_args, expected)
+
+    def test_session_reuse(self):
+        session1 = connection.get_session()
+        session2 = connection.get_session()
+        areSessionsSame = session1 is session2
+
+        adapter1 = connection.get_session().get_adapter(ApiConfig.api_protocol)
+        adapter2 = connection.get_session().get_adapter(ApiConfig.api_protocol)
+        areAdaptersSame = adapter1 is adapter2
+        
+        self.assertEqual(areAdaptersSame, True)
+        self.assertEqual(areSessionsSame, True)

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -90,6 +90,6 @@ class ConnectionTest(ModifyRetrySettingsTestCase):
         adapter1 = connection.get_session().get_adapter(ApiConfig.api_protocol)
         adapter2 = connection.get_session().get_adapter(ApiConfig.api_protocol)
         areAdaptersSame = adapter1 is adapter2
-        
+
         self.assertEqual(areAdaptersSame, True)
         self.assertEqual(areSessionsSame, True)

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,4 +1,4 @@
-import nasdaqdatalink.connection as Connection
+import nasdaqdatalink.connection as connection
 from nasdaqdatalink.api_config import ApiConfig
 from nasdaqdatalink.errors.data_link_error import (
     DataLinkError, LimitExceededError, InternalServerError,
@@ -42,7 +42,7 @@ class ConnectionTest(ModifyRetrySettingsTestCase):
 
         for expected_error in data_link_errors:
             self.assertRaises(
-                expected_error[2], lambda: Connection.request(request_method, 'databases'))
+                expected_error[2], lambda: connection.request(request_method, 'databases'))
 
     @parameterized.expand(['GET', 'POST'])
     def test_parse_error(self, request_method):
@@ -51,7 +51,7 @@ class ConnectionTest(ModifyRetrySettingsTestCase):
                                "https://data.nasdaq.com/api/v3/databases",
                                body="not json", status=500)
         self.assertRaises(
-            DataLinkError, lambda: Connection.request(request_method, 'databases'))
+            DataLinkError, lambda: connection.request(request_method, 'databases'))
 
     @parameterized.expand(['GET', 'POST'])
     def test_non_data_link_error(self, request_method):
@@ -62,7 +62,7 @@ class ConnectionTest(ModifyRetrySettingsTestCase):
                                 {'foobar':
                                  {'code': 'blah', 'message': 'something went wrong'}}), status=500)
         self.assertRaises(
-            DataLinkError, lambda: Connection.request(request_method, 'databases'))
+            DataLinkError, lambda: connection.request(request_method, 'databases'))
 
     @parameterized.expand(['GET', 'POST'])
     @patch('nasdaqdatalink.connection.execute_request')
@@ -71,7 +71,7 @@ class ConnectionTest(ModifyRetrySettingsTestCase):
         ApiConfig.api_version = '2015-04-09'
         params = {'per_page': 10, 'page': 2}
         headers = {'x-custom-header': 'header value'}
-        Connection.request(request_method, 'databases', headers=headers, params=params)
+        connection.request(request_method, 'databases', headers=headers, params=params)
         expected = call(request_method, 'https://data.nasdaq.com/api/v3/databases',
                         headers={'x-custom-header': 'header value',
                                  'x-api-token': 'api_token',

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,4 +1,4 @@
-from nasdaqdatalink.connection import Connection
+import nasdaqdatalink.connection as Connection
 from nasdaqdatalink.api_config import ApiConfig
 from nasdaqdatalink.errors.data_link_error import (
     DataLinkError, LimitExceededError, InternalServerError,
@@ -65,7 +65,7 @@ class ConnectionTest(ModifyRetrySettingsTestCase):
             DataLinkError, lambda: Connection.request(request_method, 'databases'))
 
     @parameterized.expand(['GET', 'POST'])
-    @patch('nasdaqdatalink.connection.Connection.execute_request')
+    @patch('nasdaqdatalink.connection.execute_request')
     def test_build_request(self, request_method, mock):
         ApiConfig.api_key = 'api_token'
         ApiConfig.api_version = '2015-04-09'

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -77,7 +77,7 @@ class ListDataTest(unittest.TestCase):
         httpretty.disable()
         httpretty.reset()
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_data_calls_connection(self, mock):
         Data.all(params={'database_code': 'NSE', 'dataset_code': 'OIL'})
         expected = call('get', 'datasets/NSE/OIL/data', params={})

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -7,7 +7,7 @@ from mock import call, mock_open, patch
 from six.moves.urllib.parse import parse_qs, urlparse
 
 from nasdaqdatalink.api_config import ApiConfig
-import nasdaqdatalink.connection as Connection
+import nasdaqdatalink.connection as connection
 from nasdaqdatalink.errors.data_link_error import (InternalServerError, DataLinkError)
 from nasdaqdatalink.model.database import Database
 from test.factories.database import DatabaseFactory
@@ -148,7 +148,7 @@ class BulkDownloadDatabaseTest(ModifyRetrySettingsTestCase):
 
     def test_bulk_download_to_fileaccepts_download_type(self):
         m = mock_open()
-        with patch.object(Connection, 'request') as mock_method:
+        with patch.object(connection, 'request') as mock_method:
             mock_method.return_value.url = 'https://www.blah.com/download/db.zip'
             with patch('nasdaqdatalink.model.database.open', m, create=True):
                 self.database.bulk_download_to_file(

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -7,7 +7,7 @@ from mock import call, mock_open, patch
 from six.moves.urllib.parse import parse_qs, urlparse
 
 from nasdaqdatalink.api_config import ApiConfig
-from nasdaqdatalink.connection import Connection
+import nasdaqdatalink.connection as Connection
 from nasdaqdatalink.errors.data_link_error import (InternalServerError, DataLinkError)
 from nasdaqdatalink.model.database import Database
 from test.factories.database import DatabaseFactory
@@ -34,7 +34,7 @@ class GetDatabaseTest(unittest.TestCase):
         httpretty.disable()
         httpretty.reset()
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_database_calls_connection(self, mock):
         database = Database('NSE')
         database.data_fields()
@@ -80,7 +80,7 @@ class ListDatabasesTest(unittest.TestCase):
         httpretty.disable()
         httpretty.reset()
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_databases_calls_connection(self, mock):
         Database.all()
         expected = call('get', 'databases', params={})

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -30,7 +30,7 @@ class GetDatasetTest(unittest.TestCase):
         httpretty.disable()
         httpretty.reset()
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_dataset_calls_connection(self, mock):
         d = Dataset('NSE/OIL')
         d.data_fields()
@@ -84,7 +84,7 @@ class ListDatasetsTest(unittest.TestCase):
         httpretty.disable()
         httpretty.reset()
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_datasets_calls_connection(self, mock):
         Dataset.all()
         expected = call('get', 'datasets', params={})

--- a/test/test_datatable.py
+++ b/test/test_datatable.py
@@ -37,26 +37,26 @@ class GetDatatableDatasetTest(ModifyRetrySettingsTestCase):
     def tearDown(self):
         RequestType.USE_GET_REQUEST = True
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_datatable_metadata_calls_connection(self, mock):
         Datatable('ZACKS/FC').data_fields()
         expected = call('get', 'datatables/ZACKS/FC/metadata', params={})
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_datatable_data_calls_connection_with_no_params_for_get_request(self, mock):
         Datatable('ZACKS/FC').data()
         expected = call('get', 'datatables/ZACKS/FC', params={})
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_datatable_data_calls_connection_with_no_params_for_post_request(self, mock):
         RequestType.USE_GET_REQUEST = False
         Datatable('ZACKS/FC').data()
         expected = call('post', 'datatables/ZACKS/FC', json={})
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_datatable_calls_connection_with_params_for_get_request(self, mock):
         params = {'ticker': ['AAPL', 'MSFT'],
                   'per_end_date': {'gte': '2015-01-01'},
@@ -76,7 +76,7 @@ class GetDatatableDatasetTest(ModifyRetrySettingsTestCase):
         expected = call('get', 'datatables/ZACKS/FC', params=expected_params)
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_datatable_calls_connection_with_params_for_post_request(self, mock):
         RequestType.USE_GET_REQUEST = False
         params = {'ticker': ['AAPL', 'MSFT'],

--- a/test/test_datatable_data.py
+++ b/test/test_datatable_data.py
@@ -83,7 +83,7 @@ class ListDatatableDataTest(unittest.TestCase):
     def tearDown(self):
         RequestType.USE_GET_REQUEST = True
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_data_calls_connection_get(self, mock):
         datatable = Datatable('ZACKS/FC')
         Data.page(datatable, params={'ticker': ['AAPL', 'MSFT'],
@@ -95,7 +95,7 @@ class ListDatatableDataTest(unittest.TestCase):
                                 'qopts.columns[]': ['ticker', 'per_end_date']})
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_data_calls_connection_post(self, mock):
         RequestType.USE_GET_REQUEST = False
         datatable = Datatable('ZACKS/FC')

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -8,7 +8,7 @@ from nasdaqdatalink.model.dataset import Dataset
 from nasdaqdatalink.model.merged_dataset import MergedDataset
 from nasdaqdatalink.get import get
 from nasdaqdatalink.api_config import ApiConfig
-from nasdaqdatalink.connection import Connection
+import nasdaqdatalink.connection as Connection
 
 
 class GetSingleDatasetTest(unittest.TestCase):
@@ -37,7 +37,7 @@ class GetSingleDatasetTest(unittest.TestCase):
 
     def test_setting_api_key_config(self):
         mock_connection = Mock(wraps=Connection)
-        with patch('nasdaqdatalink.connection.Connection.execute_request',
+        with patch('nasdaqdatalink.connection.execute_request',
                    new=mock_connection.execute_request) as mock:
             ApiConfig.api_key = 'api_key_configured'
             get('NSE/OIL')

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -8,7 +8,7 @@ from nasdaqdatalink.model.dataset import Dataset
 from nasdaqdatalink.model.merged_dataset import MergedDataset
 from nasdaqdatalink.get import get
 from nasdaqdatalink.api_config import ApiConfig
-import nasdaqdatalink.connection as Connection
+import nasdaqdatalink.connection as connection
 
 
 class GetSingleDatasetTest(unittest.TestCase):
@@ -36,7 +36,7 @@ class GetSingleDatasetTest(unittest.TestCase):
         self.assertIsInstance(result, numpy.core.records.recarray)
 
     def test_setting_api_key_config(self):
-        mock_connection = Mock(wraps=Connection)
+        mock_connection = Mock(wraps=connection)
         with patch('nasdaqdatalink.connection.execute_request',
                    new=mock_connection.execute_request) as mock:
             ApiConfig.api_key = 'api_key_configured'

--- a/test/test_get_point_in_time_data.py
+++ b/test/test_get_point_in_time_data.py
@@ -27,7 +27,7 @@ class GetPointInTimeTest(unittest.TestCase):
     def tearDown(self):
         RequestType.USE_GET_REQUEST = True
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_get_point_in_time_returns_data_frame_object(self, mock):
         with self.assertWarns(UserWarning):
             df = nasdaqdatalink.get_point_in_time(
@@ -36,7 +36,7 @@ class GetPointInTimeTest(unittest.TestCase):
 
         self.assertIsInstance(df, pandas.core.frame.DataFrame)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_asofdate_call_connection(self, mock):
         with self.assertWarns(UserWarning):
             nasdaqdatalink.get_point_in_time('ZACKS/FC', interval='asofdate', date='2020-01-01')
@@ -44,7 +44,7 @@ class GetPointInTimeTest(unittest.TestCase):
 
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_asofdate_call_connection_with_datetimes(self, mock):
         with self.assertWarns(UserWarning):
             nasdaqdatalink.get_point_in_time(
@@ -54,7 +54,7 @@ class GetPointInTimeTest(unittest.TestCase):
 
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_asofdate_call_without_date(self, mock):
         with self.assertWarns(UserWarning):
             nasdaqdatalink.get_point_in_time('ZACKS/FC', interval='asofdate')
@@ -62,7 +62,7 @@ class GetPointInTimeTest(unittest.TestCase):
 
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_from_call_connection(self, mock):
         with self.assertWarns(UserWarning):
             nasdaqdatalink.get_point_in_time(
@@ -75,7 +75,7 @@ class GetPointInTimeTest(unittest.TestCase):
 
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_from_call_connection_with_datetimes(self, mock):
         with self.assertWarns(UserWarning):
             nasdaqdatalink.get_point_in_time(
@@ -90,7 +90,7 @@ class GetPointInTimeTest(unittest.TestCase):
 
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_between_call_connection(self, mock):
         with self.assertWarns(UserWarning):
             nasdaqdatalink.get_point_in_time(
@@ -103,7 +103,7 @@ class GetPointInTimeTest(unittest.TestCase):
 
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_between_call_connection_with_datetimes(self, mock):
         with self.assertWarns(UserWarning):
             nasdaqdatalink.get_point_in_time(
@@ -118,7 +118,7 @@ class GetPointInTimeTest(unittest.TestCase):
 
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_invalid_interval_connection(self, mock):
         self.assertRaises(InvalidRequestError, lambda: nasdaqdatalink.get_point_in_time('ZACKS/FC'))
         self.assertRaises(
@@ -126,7 +126,7 @@ class GetPointInTimeTest(unittest.TestCase):
             lambda: nasdaqdatalink.get_point_in_time('ZACKS/FC', interval='nasdaqdatalink')
         )
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_invalid_from_connection(self, mock):
         self.assertRaises(
             InvalidRequestError,
@@ -145,7 +145,7 @@ class GetPointInTimeTest(unittest.TestCase):
             )
         )
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_invalid_between_connection(self, mock):
         self.assertRaises(
             InvalidRequestError,

--- a/test/test_get_table.py
+++ b/test/test_get_table.py
@@ -37,21 +37,21 @@ class GetDataTableTest(unittest.TestCase):
     def tearDown(self):
         RequestType.USE_GET_REQUEST = True
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_datatable_returns_datatable_object(self, mock):
         with self.assertWarns(UserWarning):
             df = nasdaqdatalink.get_table('ZACKS/FC', params={})
 
         self.assertIsInstance(df, pandas.core.frame.DataFrame)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_datatable_with_code_returns_datatable_object(self, mock):
         with self.assertWarns(UserWarning):
             df = nasdaqdatalink.get_table('AR/MWCF', code="ICEP_WAC_Z2017_S")
 
         self.assertIsInstance(df, pandas.core.frame.DataFrame)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_get_table_calls_connection_with_no_params_for_get_request(self, mock):
         with self.assertWarns(UserWarning):
             nasdaqdatalink.get_table('ZACKS/FC')
@@ -59,7 +59,7 @@ class GetDataTableTest(unittest.TestCase):
 
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_get_table_calls_connection_with_no_params_for_post_request(self, mock):
         with self.assertWarns(UserWarning):
             RequestType.USE_GET_REQUEST = False
@@ -69,7 +69,7 @@ class GetDataTableTest(unittest.TestCase):
 
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_get_table_calls_connection_with_params_for_get_request(self, mock):
         with self.assertWarns(UserWarning):
             params = {
@@ -93,7 +93,7 @@ class GetDataTableTest(unittest.TestCase):
 
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_get_table_calls_connection_with_params_for_post_request(self, mock):
         with self.assertWarns(UserWarning):
             RequestType.USE_GET_REQUEST = False

--- a/test/test_point_in_time.py
+++ b/test/test_point_in_time.py
@@ -26,7 +26,7 @@ class GetPointInTimeTest(ModifyRetrySettingsTestCase):
     def tearDown(self):
         RequestType.USE_GET_REQUEST = True
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_asofdate_call_connection(self, mock):
         PointInTime(
             'ZACKS/FC',
@@ -38,7 +38,7 @@ class GetPointInTimeTest(ModifyRetrySettingsTestCase):
         expected = call('get', 'pit/ZACKS/FC/asofdate/2020-01-01', params={})
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_from_call_connection(self, mock):
         PointInTime(
             'ZACKS/FC',
@@ -51,7 +51,7 @@ class GetPointInTimeTest(ModifyRetrySettingsTestCase):
         expected = call('get', 'pit/ZACKS/FC/from/2020-01-01/to/2020-01-02', params={})
         self.assertEqual(mock.call_args, expected)
 
-    @patch('nasdaqdatalink.connection.Connection.request')
+    @patch('nasdaqdatalink.connection.request')
     def test_between_call_connection(self, mock):
         PointInTime(
             'ZACKS/FC',

--- a/test/test_retries.py
+++ b/test/test_retries.py
@@ -1,7 +1,7 @@
 import unittest
 import json
 
-from nasdaqdatalink.connection import Connection
+import nasdaqdatalink.connection as Connection
 from nasdaqdatalink.api_config import ApiConfig
 from test.factories.datatable import DatatableFactory
 from test.helpers.httpretty_extension import httpretty


### PR DESCRIPTION
this PR changed from _session-per-request_ to _session-over-time_.

previous implementation session-per-request:
Every time we call API with get*, it will create a session within get_session() function.

Current implementation session-over-time:

1. System creates a global variable session, initially be assigned with None.
2. Once get_session() has been called for the first time, it will create the global session and setup retry strategy for it. (*)

* Retry strategy can only be setup on session level. If we create session in global, the code will not respect the `APIConfig` retry strategy (ApiConfig could be designed to be a config object to pass into each request, instead of make functions depend on a global one)

----------------------------------------------------------------------------

con:
- clients cannot change the retry strategy after the first request, (System can add a listener on ApiConfig, and every time clients change retry config, system generate a new session)


<img width="477" alt="Screen Shot 2022-04-05 at 10 01 06 PM" src="https://user-images.githubusercontent.com/97460234/161880853-b94753a2-db11-4477-bfb7-2460d446fcd8.png">



  | 1 | 5 | 50 | 100 | 500 | 1000
-- | -- | -- | -- | -- | -- | --
non-reuse - function count | 357108 | 398632 | 865777 | 1384827 | 5537227 | 10727727
reuse - function count | 357119 | 396816 | 843351 | 1339501 | 5308701 | 10270201
  |   |   |   |   |   |  
  | 1 | 5 | 50 | 100 | 500 | 1000
non-reuse - second | 0.55 | 0.69 | 1.42 | 2.43 | 8.71 | 16.768
reuse - second | 0.53 | 0.61 | 0.9 | 1.38 | 4.67 | 8.68




