### PR TITLE
docs: update read_key() filepath -> filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ explicitly call `read_key()` with a custom path.  See below:
 
 ```python
 import nasdaqdatalink
-nasdaqdatalink.read_key(filepath="/data/.corporatenasdaqdatalinkapikey")
+nasdaqdatalink.read_key(filename="/data/.corporatenasdaqdatalinkapikey")
 ```
 
 ## Retrieving Data


### PR DESCRIPTION
Documentation provides old `reak_key()` `filepath` argument. New argument is  `filename`:

https://github.com/Nasdaq/data-link-python/blob/86c5665ba67b5e67e1e2fe6204b361f14c0a6cb8/nasdaqdatalink/api_config.py#L100-L104