### PR TITLE
connection: update session with proxies if available

### DIFF
--- a/nasdaqdatalink/connection.py
+++ b/nasdaqdatalink/connection.py
@@ -1,6 +1,7 @@
 import re
 
 import requests
+import urllib
 
 from urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
@@ -61,6 +62,10 @@ class Connection:
         session = requests.Session()
         adapter = HTTPAdapter(max_retries=cls.get_retries())
         session.mount(ApiConfig.api_protocol, adapter)
+
+        proxies = urllib.request.getproxies()
+        if proxies is not None:
+            session.proxies.update(proxies)
 
         return session
 


### PR DESCRIPTION
It was erroneously assumed that new Session objects would include proxy
details, especially when env vars are defined.

Fixes an issue where users stuck behind a corporate firewall cannot
reach the api endpoint because the underlying liburl requests is not
updated.

Check if proxies are available and update the Session.

Signed-off-by: Jamie Couture <jamie.couture@nasdaq.com>