### PR TITLE
DLPLAT-999/handling-errors: Errors were not being reported correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.3 - 2022-08-07
+
+* Fixes an issue with errors not being reported correctly.
+
 ### 1.0.2 - 2022-05-02
 
 * Fixes an issue with sessions not respecting proxy settings.

--- a/nasdaqdatalink/connection.py
+++ b/nasdaqdatalink/connection.py
@@ -97,11 +97,11 @@ class Connection:
 
         # if our app does not form a proper data_link_error response
         # throw generic error
-        if 'error' not in error_body:
+        if 'quandl_error' not in error_body:
             raise DataLinkError(http_status=resp.status_code, http_body=resp.text)
 
-        code = error_body['error']['code']
-        message = error_body['error']['message']
+        code = error_body['quandl_error']['code']
+        message = error_body['quandl_error']['message']
         prog = re.compile('^QE([a-zA-Z])x')
         if prog.match(code):
             code_letter = prog.match(code).group(1)

--- a/nasdaqdatalink/version.py
+++ b/nasdaqdatalink/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.2'
+VERSION = '1.0.3'

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -35,7 +35,7 @@ class ConnectionTest(ModifyRetrySettingsTestCase):
         httpretty.register_uri(getattr(httpretty, request_method),
                                "https://data.nasdaq.com/api/v3/databases",
                                responses=[httpretty.Response(body=json.dumps(
-                                   {'error':
+                                   {'quandl_error':
                                     {'code': x[0], 'message': 'something went wrong'}}),
                                    status=x[1]) for x in data_link_errors]
                                )

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -179,7 +179,7 @@ class BulkDownloadDatabaseTest(ModifyRetrySettingsTestCase):
                                re.compile(
                                    'https://data.nasdaq.com/api/v3/databases/*'),
                                body=json.dumps(
-                                   {'error':
+                                   {'quandl_error':
                                     {'code': 'QEMx01', 'message': 'something went wrong'}}),
                                status=500)
 

--- a/test/test_datatable.py
+++ b/test/test_datatable.py
@@ -186,7 +186,7 @@ class ExportDataTableTest(unittest.TestCase):
         ApiConfig.number_of_retries = 2
         error_responses = [httpretty.Response(
             body=json.dumps(
-              {'error': {'code': 'QEMx01', 'message': 'something went wrong'}}
+              {'quandl_error': {'code': 'QEMx01', 'message': 'something went wrong'}}
             ),
             status=500)]
 

--- a/test/test_retries.py
+++ b/test/test_retries.py
@@ -39,7 +39,7 @@ class TestRetries(ModifyRetrySettingsTestCase):
 
         cls.error_response = httpretty.Response(
             body=json.dumps(
-              {'error': {'code': 'QEMx01', 'message': 'something went wrong'}}
+              {'quandl_error': {'code': 'QEMx01', 'message': 'something went wrong'}}
             ),
             status=500)
         cls.success_response = httpretty.Response(body=json.dumps(cls.datatable), status=200)


### PR DESCRIPTION
Errors were being passed by the API however, they were not being reported correctlly.